### PR TITLE
Removed memory allocation from Ari encoding.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,12 @@ check: test doctest
 test: $(LIBTEST)
 	$(LIBTEST)
 
+bench: $(LIBTEST)
+	$(LIBTEST) --bench
+
 $(LIBTEST): lib.rs
 	@mkdir -p $(@D)
-	$(RUSTC) --test --out-dir $(@D) lib.rs --dep-info
+	$(RUSTC) $(RUSTFLAGS) --test --out-dir $(@D) lib.rs --dep-info
 
 doctest: $(COMPRESS)
 	$(RUSTDOC) --test lib.rs -L build


### PR DESCRIPTION
This change increases Ari encoding speed by about 50% (from 870us/iter to 513us/iter). Also adds the bench mode for the Makefile.
