### PR TITLE
Fixed all owned vectors to use vec_ng::Vec instead

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ bench: $(LIBTEST)
 
 $(LIBTEST): lib.rs
 	@mkdir -p $(@D)
-	$(RUSTC) $(RUSTFLAGS) --test --out-dir $(@D) lib.rs --dep-info
+	$(RUSTC) $(RUSTFLAGS) --test -A deprecated_owned_vector --out-dir $(@D) lib.rs --dep-info
 
 doctest: $(COMPRESS)
 	$(RUSTDOC) --test lib.rs -L build

--- a/bwt/mtf.rs
+++ b/bwt/mtf.rs
@@ -171,16 +171,18 @@ impl<R: Reader> Reader for Decoder<R> {
 mod test {
     use test;
     use std::io;
+    use std::vec_ng::Vec;
     use super::{Encoder, Decoder};
 
     fn roundtrip(bytes: &[u8]) {
         info!("Roundtrip MTF of size {}", bytes.len());
         let mut e = Encoder::new(io::MemWriter::new());
         e.write(bytes).unwrap();
-        let encoded = e.finish().unwrap();
-        debug!("Roundtrip MTF input: {:?}, ranks: {:?}", bytes, encoded);
-        let mut d = Decoder::new(io::BufReader::new(encoded));
-        let decoded = d.read_to_end().unwrap();
+        let encoded = e.finish();
+        debug!("Roundtrip MTF input: {:?}, ranks: {:?}", bytes, encoded.get_ref());
+        let mut d = Decoder::new(io::BufReader::new(encoded.get_ref()));
+        //let decoded = d.read_to_end().unwrap();
+        let decoded: Vec<u8> = d.bytes().map(|x| x.unwrap()).collect();
         assert_eq!(decoded.as_slice(), bytes);
     }
 
@@ -207,10 +209,10 @@ mod test {
         let input = include_bin!("../data/test.txt");
         let mut e = Encoder::new(io::MemWriter::new());
         e.write(input).unwrap();
-        let encoded = e.finish().unwrap();
+        let encoded = e.finish();
         bh.iter(|| {
-            let mut d = Decoder::new(io::BufReader::new(encoded));
-            d.read_to_end().unwrap();
+            let mut d = Decoder::new(io::BufReader::new(encoded.get_ref()));
+            d.bytes().fold((), |u,_| u);
         });
         bh.bytes = input.len() as u64;
     }

--- a/entropy/ari.rs
+++ b/entropy/ari.rs
@@ -32,7 +32,8 @@ This is an original implementation.
 
 */
 
-use std::{io, vec};
+use std::io;
+use std::vec_ng::Vec;
 #[cfg(tune)]
 use std::num;
 
@@ -169,7 +170,7 @@ pub static range_default_threshold: Border = 1<<14;
 
 /// Encode 'value', using a model and a range encoder
 /// returns a list of output bytes
-pub fn encode<M: Model>(value: Value, model: &M, re: &mut RangeEncoder, accum: &mut ~[Symbol]) {
+pub fn encode<M: Model>(value: Value, model: &M, re: &mut RangeEncoder, accum: &mut Vec<Symbol>) {
     let (lo, hi) = model.get_range(value);
     let total = model.get_denominator();
     debug!("\tEncoding value {} of range [{}-{}) with total {}", value, lo, hi, total);
@@ -193,7 +194,7 @@ pub fn decode<M: Model>(code: Border, model: &M, re: &mut RangeEncoder) -> (Valu
 pub struct Encoder<W> {
     priv stream: W,
     priv range: RangeEncoder,
-    priv buffer: ~[Symbol],
+    priv buffer: Vec<Symbol>,
     priv bytes_written: uint,
 }
 
@@ -203,7 +204,7 @@ impl<W: Writer> Encoder<W> {
         Encoder {
             stream: w,
             range: RangeEncoder::new(range_default_threshold),
-            buffer: vec::with_capacity(4),
+            buffer: Vec::with_capacity(4),
             bytes_written: 0,
         }
     }
@@ -213,7 +214,7 @@ impl<W: Writer> Encoder<W> {
         self.buffer.truncate(0);
         encode(value, model, &mut self.range, &mut self.buffer);
         self.bytes_written += self.buffer.len();
-        self.stream.write(self.buffer)
+        self.stream.write(self.buffer.as_slice())
     }
 
     /// Finish decoding by writing the code tail word
@@ -276,7 +277,7 @@ impl<R: Reader> Decoder<R> {
         let (value,shift) = decode(self.code, model, &mut self.range);
         self.bytes_read += shift;
         for b in self.stream.bytes().take(shift) {
-            self.code = (self.code<<8) + (b as Border);
+            self.code = (self.code<<8) + (b.unwrap() as Border);
         }
         Ok(value)
     }
@@ -452,7 +453,7 @@ pub struct FrequencyTable {
     /// sum of frequencies
     priv total: Border,
     /// main table: value -> Frequency
-    priv table: ~[Frequency],
+    priv table: Vec<Frequency>,
     /// maximum allowed sum of frequency,
     /// should be smaller than RangeEncoder::threshold
     priv cut_threshold: Border,
@@ -463,7 +464,7 @@ pub struct FrequencyTable {
 impl FrequencyTable {
     /// Create a new table with frequencies initialized by a function
     pub fn new_custom(num_values: uint, threshold: Border, fn_init: |Value|-> Frequency) -> FrequencyTable {
-        let freq = vec::from_fn(num_values, fn_init);
+        let freq = Vec::from_fn(num_values, fn_init);
         let total = freq.iter().fold(0 as Border, |u,&f| u+(f as Border));
         let mut ft = FrequencyTable {
             total: total,
@@ -498,7 +499,7 @@ impl FrequencyTable {
         let add = (self.total>>add_log) + add_const;
         assert!(add < 2*self.cut_threshold);
         debug!("\tUpdating by adding {} to value {}", add, value);
-        self.table[value] += add as Frequency;
+        *self.table.get_mut(value) += add as Frequency;
         self.total += add;
         if self.total >= self.cut_threshold {
             self.downscale();
@@ -527,7 +528,7 @@ impl FrequencyTable {
 impl Model for FrequencyTable {
     fn get_range(&self, value: Value) -> (Border,Border) {
         let lo = self.table.slice_to(value).iter().fold(0, |u,&f| u+(f as Border));
-        (lo, lo + (self.table[value] as Border))
+        (lo, lo + (*self.table.get(value) as Border))
     }
 
     fn find_value(&self, offset: Border) -> (Value,Border,Border) {
@@ -537,7 +538,7 @@ impl Model for FrequencyTable {
         let mut value = 0u;
         let mut lo = 0 as Border;
         let mut hi;
-        while {hi=lo+(self.table[value] as Border); hi} <= offset {
+        while {hi=lo+(*self.table.get(value) as Border); hi} <= offset {
             lo = hi;
             value += 1;
         }
@@ -701,7 +702,7 @@ impl<R: Reader> Reader for ByteDecoder<R> {
 #[cfg(test)]
 mod test {
     use std::io::{BufReader, BufWriter, MemWriter, SeekSet};
-    use std::vec;
+    use std::vec_ng::Vec;
     use test;
 
     fn roundtrip(bytes: &[u8]) {
@@ -710,14 +711,13 @@ mod test {
         e.write(bytes).unwrap();
         let (e, r) = e.finish();
         r.unwrap();
-        let encoded = e.unwrap();
-        debug!("Roundtrip input {:?} encoded {:?}", bytes, encoded);
-        let mut d = super::ByteDecoder::new(BufReader::new(encoded));
-        let decoded = d.read_to_end().unwrap();
+        debug!("Roundtrip input {:?} encoded {:?}", bytes, e.get_ref());
+        let mut d = super::ByteDecoder::new(BufReader::new(e.get_ref()));
+        let decoded: Vec<u8> = d.bytes().map(|b| b.unwrap()).collect();
         assert_eq!(bytes.as_slice(), decoded.as_slice());
     }
 
-    fn encode_binary(bytes: &[u8], model: &mut super::BinaryModel, factor: uint) -> ~[u8] {
+    fn encode_binary<'a>(bytes: &[u8], model: &mut super::BinaryModel, factor: uint) -> MemWriter {
         let mut encoder = super::Encoder::new(MemWriter::new());
         for &byte in bytes.iter() {
             for i in range(0,8) {
@@ -728,14 +728,14 @@ mod test {
         }
         let (writer, err) = encoder.finish();
         err.unwrap();
-        writer.unwrap()
+        writer
     }
 
     fn roundtrip_binary(bytes: &[u8], factor: uint) {
         let mut bm = super::BinaryModel::new_flat(super::range_default_threshold >> 3);
         let output = encode_binary(bytes, &mut bm, factor);
         bm.reset_flat();
-        let mut decoder = super::Decoder::new(BufReader::new(output));
+        let mut decoder = super::Decoder::new(BufReader::new(output.get_ref()));
         decoder.start().unwrap();
         for &byte in bytes.iter() {
             let mut value = 0u8;
@@ -781,13 +781,12 @@ mod test {
         }
         let (writer, err) = encoder.finish();
         err.unwrap();
-        let buffer = writer.unwrap();
         // decode
         t0.reset_flat();
         t1.reset_flat();
         b0.reset_flat();
         b1.reset_flat();
-        let mut decoder = super::Decoder::new(BufReader::new(buffer));
+        let mut decoder = super::Decoder::new(BufReader::new(writer.get_ref()));
         decoder.start().unwrap();
         for &byte in bytes.iter() {
             let high = {
@@ -832,9 +831,9 @@ mod test {
     #[bench]
     fn compress_speed(bh: &mut test::BenchHarness) {
         let input = include_bin!("../data/test.txt");
-        let mut storage = vec::from_elem(input.len(), 0u8);
+        let mut storage = Vec::from_elem(input.len(), 0u8);
         bh.iter(|| {
-            let mut w = BufWriter::new(storage);
+            let mut w = BufWriter::new(storage.as_mut_slice());
             w.seek(0, SeekSet).unwrap();
             let mut e = super::ByteEncoder::new(w);
             e.write(input).unwrap();

--- a/main.rs
+++ b/main.rs
@@ -13,7 +13,8 @@ extern crate compress;
 extern crate collections;
 
 use collections::HashMap;
-use std::{io, os, str, vec};
+use std::{io, str};
+use std::vec_ng::Vec;
 use compress::{bwt, lz4};
 //use compress::entropy::ari;
 
@@ -22,7 +23,7 @@ static MAGIC    : u32   = 0x73632172;   //=r!cs
 
 struct Config {
     exe_name: ~str,
-    methods: ~[~str],
+    methods: Vec<~str>,
     block_size: uint,
     decompress: bool,
 }
@@ -31,7 +32,7 @@ impl Config {
     fn query(args: &[~str]) -> Config {
         let mut cfg = Config {
             exe_name: args[0].clone(),
-            methods: ~[],
+            methods: Vec::new(),
             block_size: 1<<16,
             decompress: false,
         };
@@ -118,7 +119,8 @@ pub fn main() {
         info: ~"Ziv-Lempel derivative, focused at speed",
     });
 
-    let config = Config::query(os::args());
+    //let config = Config::query(os::args());
+    let config = Config::query(&[~"app"]); // temporary, until we have os::args() fixed
     let mut input = io::stdin();
     let mut output = io::stdout();
     if config.decompress {
@@ -134,10 +136,10 @@ pub fn main() {
             },
             _ => () //OK
         }
-        let methods = vec::from_fn( input.read_u8().unwrap() as uint, |_| {
+        let methods = Vec::from_fn( input.read_u8().unwrap() as uint, |_| {
             let len = input.read_u8().unwrap() as uint;
-            let bytes = input.read_bytes(len).unwrap();
-            str::from_utf8(bytes).unwrap().to_owned()
+            let bytes: Vec<u8> = input.bytes().map(|x| x.unwrap()).take(len).collect();
+            str::from_utf8(bytes.as_slice()).unwrap().to_owned()
         });
         let mut rsum: ~Reader = ~input;
         for met in methods.iter() {

--- a/zlib.rs
+++ b/zlib.rs
@@ -125,20 +125,16 @@ impl<R: Reader> Reader for Decoder<R> {
 }
 
 #[cfg(test)]
-#[allow(warnings)]
 mod test {
     use rand;
     use test;
-    use std::io::{BufReader, MemWriter};
+    use std::io::{BufReader};
+    use std::vec_ng::Vec;
     use super::{Decoder};
-    use std::str;
 
     fn test_decode(input: &[u8], output: &[u8]) {
         let mut d = Decoder::new(BufReader::new(input));
-        let got = match d.read_to_end() {
-            Ok(b) => b,
-            Err(e) => fail!("error reading: {}", e),
-        };
+        let got: Vec<u8> = d.bytes().map(|b| b.unwrap()).collect();
         assert!(got.as_slice() == output);
     }
 
@@ -168,7 +164,7 @@ mod test {
         let input = include_bin!("data/test.z.1");
         let mut d = Decoder::new(BufReader::new(input));
         assert!(!d.eof());
-        let mut out = ~[];
+        let mut out = Vec::new();
         loop {
             match d.read_byte() {
                 Ok(b) => out.push(b),
@@ -183,7 +179,7 @@ mod test {
     fn random_byte_lengths() {
         let input = include_bin!("data/test.z.1");
         let mut d = Decoder::new(BufReader::new(input));
-        let mut out = ~[];
+        let mut out = Vec::new();
         let mut buf = [0u8, ..40];
         loop {
             match d.read(buf.mut_slice_to(1 + rand::random::<uint>() % 40)) {


### PR DESCRIPTION
There are still some rough edges, like all `push_bytes()` and `read_to_end()` are replaced by workarounds. Also, the app is not operational due to os::args not being available. But hey, at least the lib compiles and the tests pass now!
