### PR TITLE
Added LZ4 block decompression.

### DIFF
--- a/src/lz4.rs
+++ b/src/lz4.rs
@@ -406,6 +406,20 @@ impl<W: Writer> Writer for Encoder<W> {
     }
 }
 
+
+/// Decodes pure LZ4 block into output. Returns count of bytes
+/// processed.
+pub fn decode_block(input: &[u8], output: &mut Vec<u8>) -> uint {
+    let mut b = BlockDecoder {
+        input: input,
+        output: output,
+        cur: 0,
+        start: 0,
+        end: 0
+    };
+    b.decode()
+}
+
 #[cfg(test)]
 mod test {
     use std::io::{BufReader, MemWriter};


### PR DESCRIPTION
It's extremely useful to uncompress pure LZ4 data which is used as a part of other formats (i.e. it doesn't use LZ4 official stream format)
