### PR TITLE
Using `log` from crates.io to avoid compile errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,6 @@ zlib = []
 [[bin]]
 name = "compress"
 doc = false
+
+[dependencies]
+log = "0.1.6"


### PR DESCRIPTION
As in-tree module is always presented and almost all crates have already
migrated to using external `log` module, there are always problems
while using this crate